### PR TITLE
add test net to ethereum, integrated chain id and code refactoring

### DIFF
--- a/packages/backend/src/lib/Ethereum/Ethereum.ts
+++ b/packages/backend/src/lib/Ethereum/Ethereum.ts
@@ -16,7 +16,9 @@ import { BlockchainConfigMintNFT } from '../BlockchainConfig/BlockchainConfigMin
 
 export class Ethereum implements Blockchain {
   async estimate_gas_fee_mint(config: EthereumConfigMintNFT): Promise<number> {
-    const provider = ethers.providers.getDefaultProvider(config.server_uri);
+    const provider = ethers.providers.getDefaultProvider(
+      isNaN(Number(config.endPoint)) ? config.endPoint : Number(config.endPoint)
+    );
     // console.log('Gasprice: ' + provider.getGasPrice());
 
     const contract = new ethers.Contract(
@@ -56,7 +58,11 @@ export class Ethereum implements Blockchain {
   async deploy_contract(config: EthereumConfigDeployContract): Promise<string> {
     // get ABI and contract byte code
     const contractInfo = Ethereum._compile_contract(config.path_to_contract);
-    const provider = ethers.providers.getDefaultProvider(config.server_uri);
+    const provider = ethers.providers.getDefaultProvider(
+      isNaN(Number(config.server_uri))
+        ? config.server_uri
+        : Number(config.server_uri)
+    );
 
     // Use your wallet's private key to deploy the contract, private key of content owner
     const wallet = new ethers.Wallet(
@@ -88,7 +94,9 @@ export class Ethereum implements Blockchain {
    */
   async mint_nft(config: EthereumConfigMintNFT): Promise<string> {
     await sleep(10000);
-    const provider = ethers.providers.getDefaultProvider(config.server_uri);
+    const provider = ethers.providers.getDefaultProvider(
+      isNaN(Number(config.endPoint)) ? config.endPoint : Number(config.endPoint)
+    );
 
     const wallet = new ethers.Wallet(config.private_key_transmitter, provider);
 

--- a/packages/backend/src/lib/Ethereum/EthereumConfig/EthereumConfigMintNFT.ts
+++ b/packages/backend/src/lib/Ethereum/EthereumConfig/EthereumConfigMintNFT.ts
@@ -1,14 +1,14 @@
 import { BlockchainConfigMintNFT } from '../../BlockchainConfig/BlockchainConfigMintNFT';
 
 export class EthereumConfigMintNFT extends BlockchainConfigMintNFT {
-  server_uri: string;
+  endPoint: string;
   private_key_transmitter: string;
   address_of_contract: string;
   pub_key_NFT_receiver: string;
   gas_limit: number;
   constructor(
     NFT_name: string,
-    server_uri: string,
+    endPoint: string,
     private_key_transmitter: string,
     address_of_contract: string,
     pub_key_NFT_receiver: string,
@@ -17,7 +17,7 @@ export class EthereumConfigMintNFT extends BlockchainConfigMintNFT {
     gas_limit: number
   ) {
     super(NFT_name, 'EthereumConfigMintNFT', url_to_file, hash);
-    this.server_uri = server_uri;
+    this.endPoint = endPoint;
     this.private_key_transmitter = private_key_transmitter;
     this.address_of_contract = address_of_contract;
     this.pub_key_NFT_receiver = pub_key_NFT_receiver;

--- a/packages/middleware/src/lib/SettingsData.ts
+++ b/packages/middleware/src/lib/SettingsData.ts
@@ -38,7 +38,7 @@ export class SettingsData {
       config: [
         {
           blockchain: string;
-          settings: { GAS_LIMIT: number; server_uri: string };
+          settings: { GAS_LIMIT: number; end_point: string };
         }
       ];
       log_file: string;
@@ -47,7 +47,7 @@ export class SettingsData {
     info.config.forEach((entry) => {
       if (entry.blockchain == this._blockchain) {
         this._GAS_LIMIT = entry.settings.GAS_LIMIT;
-        this._SERVER_URI = entry.settings.server_uri;
+        this._SERVER_URI = entry.settings.end_point;
       }
     });
 

--- a/settings.json
+++ b/settings.json
@@ -4,14 +4,14 @@
       "blockchain": "Ethereum",
       "settings": {
         "GAS_LIMIT": "2000000",
-        "server_uri": "HTTP://127.0.0.1:7545"
+        "end_point": "3"
       }
     },
     {
       "blockchain": "Solana",
       "settings": {
         "GAS_LIMIT": "2000000",
-        "server_uri": "https://api.devnet.solana.com"
+        "end_point": "https://api.devnet.solana.com"
       }
     }
   ],


### PR DESCRIPTION
This branch enables the connection to a public test net from ethereum. For this the user can modify the settings.json and provide the URL or the Chain-ID to the Network. We also did some small renaming work.

Closes #59 #100